### PR TITLE
Release/1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,43 +34,45 @@ A Model Context Protocol (MCP) server that lets AI assistants interact with macO
 
 ## Requirements
 
-- macOS with Messages.app configured (and opened at least once).
+- macOS with Messages.app configured (and opened at least once). Verified on macOS 26.0.1 (Sequoia); earlier releases should work as long as Messages.app exposes `chat.db`.
 - Node.js 18 or newer (tested on Node 22 in CI).
 - Terminal/iTerm (or whichever shell runs the server) must have **Full Disk Access** to read Messages data.
 
 ## Quick Start
 
 ```bash
-npm install
-npm run build
-npm start # stdio MCP server
+pnpm install
+pnpm run build
+pnpm start # stdio MCP server
 ```
 
-During development you can run `npm run dev` (ts-node) and use the MCP Inspector:
+During development you can run `pnpm run dev` (ts-node) and use the MCP Inspector:
 
 ```bash
-npm run inspector
+pnpm run inspector
 ```
 
 Helper scripts:
 
-- `npm run send -- "+1XXXXXXXXXX" "Hello"` – send a quick test message.
-- `npm run doctor` / `npm run doctor -- --json` – verify prerequisites.
+- `pnpm run send -- "+1XXXXXXXXXX" "Hello"` – send a quick test message.
+- `pnpm run doctor` / `pnpm run doctor -- --json` – verify prerequisites.
 
-### Install via npm / npx
+### Install via npm / pnpm
 
 Once a release is published to npm you can install or run the package directly:
 
 ```bash
 # one-shot usage
-npx messages-mcp --help
+pnpm dlx messages-mcp --help
+# (or use `npx messages-mcp --help` if you prefer npm)
 
 # or install globally
-npm install -g messages-app-mcp
+pnpm add -g messages-app-mcp
+# (or `npm install -g messages-app-mcp`)
 messages-mcp --help
 ```
 
-The binary exposed by npm is identical to `dist/index.js`; all runtime requirements (Full Disk Access, Node 18+) still apply.
+The binary exposed by npm (or installed via pnpm) is identical to `dist/index.js`; all runtime requirements (Full Disk Access, Node 18+) still apply.
 
 ## Tool Reference
 
@@ -107,24 +109,24 @@ Grant Full Disk Access before running the server so SQLite reads succeed. Withou
 
 ## Development
 
-- `npm run dev` starts the stdio server via ts-node.
-- `npm run build` compiles TypeScript to `dist/`; run `npm start` to execute the compiled build.
-- An MCP Inspector session can be launched with `npm run inspector`.
-- Scripts are documented in `package.json`; use `npm run send` or `npm run doctor` for quick manual checks.
+- `pnpm run dev` starts the stdio server via ts-node.
+- `pnpm run build` compiles TypeScript to `dist/`; run `pnpm start` to execute the compiled build.
+- An MCP Inspector session can be launched with `pnpm run inspector`.
+- Scripts are documented in `package.json`; use `pnpm run send` or `pnpm run doctor` for quick manual checks.
 
 ## Testing
 
-- `npm test` runs Vitest with coverage (see `tests/utils/*.spec.ts`).
+- `pnpm test` runs Vitest with coverage (see `tests/utils/*.spec.ts`).
 - Focus tests on edge cases: mixed chat schemas, Apple epoch conversions, structured response shapes.
 - CI (GitHub Actions, macOS) runs install → test → build → doctor; keep workflows green before cutting a release.
 
 ## Release Process
 
-1. Ensure `npm run build` and `npm test` pass locally.
+1. Ensure `pnpm run build` and `pnpm test` pass locally.
 2. Update documentation (this README, `CONTRIBUTING.md`) if tool contracts change.
 3. Bump `package.json` and mention the change in your commit message/PR.
 4. Tag releases after merging to `main`; the `about` tool will automatically reflect the new version and commit hash.
-5. Publish to npm with `npm publish --access public` (or rely on the GitHub Actions release workflow which publishes when an `v*` tag is pushed and `NPM_TOKEN` is configured).
+5. Publish to npm with `pnpm publish --access public` (or rely on the GitHub Actions release workflow which publishes when an `v*` tag is pushed and `NPM_TOKEN` is configured).
 6. **Recommended dry run:** create a pre-release tag (e.g., `v1.1.0-rc1`) without `NPM_TOKEN` set to confirm the workflow completes build/test and exercises the “skip publish” path before cutting a public release.
 
 ## Security Notes
@@ -179,9 +181,9 @@ These snippets show how to connect common MCP clients:
 **Direct CLI session**
 
 ```bash
-npx messages-mcp --help
+pnpm dlx messages-mcp --help
 # or run the stdio server manually
-eval "$(npm prefix)/bin/messages-mcp"
+pnpm dlx messages-mcp
 ```
 
 For HTTP transport, launch `node dist/index.js --http --port 3333 --cors-origin https://chat.openai.com` and point the client at the resulting base URL.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messages-app-mcp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Model Context Protocol server for macOS Messages.app (list chats, read history, send messages)",
   "type": "module",
   "main": "dist/index.js",
@@ -15,10 +15,17 @@
     "send": "node scripts/send.mjs",
     "doctor": "node scripts/doctor.mjs",
     "doctor:json": "node scripts/doctor.mjs --json",
-    "inspector": "npx @modelcontextprotocol/inspector node dist/index.js",
-    "prepare": "npm run build"
+    "inspector": "pnpm dlx @modelcontextprotocol/inspector node dist/index.js",
+    "prepare": "pnpm run build"
   },
-  "keywords": [],
+  "keywords": [
+    "model-context-protocol",
+    "mcp",
+    "messages",
+    "imessage",
+    "sms",
+    "apple"
+  ],
   "author": "Matthias",
   "license": "MIT",
   "homepage": "https://github.com/Baphomet480/messages-app-mcp#readme",
@@ -33,14 +40,6 @@
     "dist",
     "LICENSE",
     "README.md"
-  ],
-  "keywords": [
-    "model-context-protocol",
-    "mcp",
-    "messages",
-    "imessage",
-    "sms",
-    "apple"
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.0",
@@ -57,5 +56,14 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
+  },
+  "pnpm": {
+    "allowedBuiltDependencies": [
+      "esbuild",
+      "sqlite3"
+    ],
+    "onlyBuiltDependencies": [
+      "sqlite3"
+    ]
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import {
 } from "./utils/sqlite.js";
 import { buildSendFailurePayload, buildSendSuccessPayload } from "./utils/send-result.js";
 import type { MessageLike, SendTargetDescriptor } from "./utils/send-result.js";
-import { getVersionInfo } from "./utils/version.js";
+import { getVersionInfo, getVersionInfoSync } from "./utils/version.js";
 import { runDoctor } from "./utils/doctor.js";
 import type { EnrichedMessageRow, AttachmentInfo } from "./utils/sqlite.js";
 
@@ -432,10 +432,32 @@ function normalizeAttachment(info: AttachmentInfo) {
   };
 }
 
+const SERVER_INSTRUCTIONS = [
+  "messages-app-mcp bridges macOS Messages.app to MCP clients.",
+  "",
+  "Core tools:",
+  "- list_chats / get_messages / context_around_message: browse conversation history with attachment metadata.",
+  "- send_text / send_attachment: deliver new messages when MESSAGES_MCP_READONLY is not set.",
+  "- search_messages / search_messages_safe / search: scoped full-text search utilities with connector-friendly output.",
+  "- doctor: verifies AppleScript, Full Disk Access, and accounts before sending.",
+  "- about: returns version, git commit, and runtime environment.",
+  "",
+  "Grant Full Disk Access to the invoking shell so chat.db can be read and attachments can be sent.",
+].join("\n");
+
 function createConfiguredServer(): McpServer {
+  const versionInfo = getVersionInfoSync();
   const server = new McpServer(
-    { name: "messages-app-mcp", version: "0.1.0" },
-    {}
+    {
+      name: versionInfo.name,
+      title: "Messages.app MCP Server",
+      version: versionInfo.version,
+      description: "Expose macOS Messages history, search, and sending flows over MCP.",
+      websiteUrl: "https://github.com/Baphomet480/messages-app-mcp",
+    },
+    {
+      instructions: SERVER_INSTRUCTIONS,
+    }
   );
 
   const sendTextInputSchema = {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,5 +1,8 @@
 import { execFile } from "node:child_process";
-import pkg from "../../package.json";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { name?: string; version?: string };
 
 export type VersionInfo = {
   name: string;

--- a/tests/utils/applescript.spec.ts
+++ b/tests/utils/applescript.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execFileMock = vi.fn<(typeof import("node:child_process"))['execFile']>();
+const defaultExecImplementation: (typeof import("node:child_process"))['execFile'] = ((cmd: any, args: any, options: any, callback: any) => {
+  if (typeof options === "function") {
+    callback = options;
+  }
+  callback?.(null, Buffer.from("ok"), Buffer.from(""));
+  return {} as any;
+}) as any;
+
+const statMock = vi.fn(async () => ({
+  isFile: () => true,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: (...args: Parameters<typeof defaultExecImplementation>) => execFileMock(...args),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  stat: (...args: Parameters<typeof statMock>) => statMock(...args),
+}));
+
+vi.mock("node:os", () => ({
+  homedir: () => "/Users/tester",
+}));
+
+vi.mock("node:path", async () => {
+  const actual = await vi.importActual<typeof import("node:path")>("node:path");
+  return actual;
+});
+
+import {
+  sendMessageAppleScript,
+  sendAttachmentAppleScript,
+  MESSAGES_FDA_HINT,
+} from "../../src/utils/applescript.js";
+
+beforeEach(() => {
+  execFileMock.mockReset();
+  execFileMock.mockImplementation(defaultExecImplementation as any);
+  statMock.mockReset();
+  statMock.mockResolvedValue({
+    isFile: () => true,
+  });
+});
+
+describe("sendMessageAppleScript", () => {
+  it("throws if message text is empty", async () => {
+    await expect(sendMessageAppleScript("+15550001111", "  ")).rejects.toThrow(
+      "Message text must not be empty.",
+    );
+  });
+
+  it("invokes osascript with recipient mode for string targets", async () => {
+    await sendMessageAppleScript("  +15550000000  ", " Hello there ");
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const callArgs = execFileMock.mock.calls[0]!;
+    const args = callArgs[1] as string[];
+    expect(args[0]).toBe("-l");
+    expect(args[1]).toBe("AppleScript");
+    expect(args[3]).toContain("on run argv");
+    expect(args.slice(-4)).toEqual(["text", "recipient", "+15550000000", " Hello there "]);
+  });
+
+  it("prefers chat identifiers when provided", async () => {
+    await sendMessageAppleScript(
+      { chatGuid: "chat123", chatName: "Ignore" },
+      "ping",
+    );
+
+    const callArgs = execFileMock.mock.calls[0]!;
+    const args = callArgs[1] as string[];
+    expect(args.slice(-4)).toEqual(["text", "chat", "chat123", "ping"]);
+  });
+});
+
+describe("sendAttachmentAppleScript", () => {
+  it("normalizes tilded paths and sends attachment", async () => {
+    await sendAttachmentAppleScript("friend", "~/Desktop/notes.txt", " optional caption ");
+
+    expect(statMock).toHaveBeenCalledWith("/Users/tester/Desktop/notes.txt");
+    const callArgs = execFileMock.mock.calls[0]!;
+    const args = callArgs[1] as string[];
+    expect(args.slice(-5)).toEqual([
+      "file",
+      "recipient",
+      "friend",
+      "/Users/tester/Desktop/notes.txt",
+      " optional caption ",
+    ]);
+  });
+
+  it("rejects when the path does not point to a file", async () => {
+    statMock.mockResolvedValueOnce({
+      isFile: () => false,
+    });
+
+    await expect(sendAttachmentAppleScript("friend", "/tmp", undefined)).rejects.toThrow(
+      /is not a file/,
+    );
+  });
+
+  it("rejects with helpful message when file is missing", async () => {
+    const enoent = Object.assign(new Error("nope"), { code: "ENOENT" });
+    statMock.mockRejectedValueOnce(enoent);
+
+    await expect(sendAttachmentAppleScript("friend", "/missing.txt", undefined)).rejects.toThrow(
+      /Attachment not found/,
+    );
+  });
+
+  it("maps osascript POSIX errors to Full Disk Access hint", async () => {
+    execFileMock.mockImplementationOnce((cmd: any, args: any, opts: any, cb: any) => {
+      cb(new Error("POSIX file error"), Buffer.from(""), Buffer.from("POSIX file error"));
+      return {} as any;
+    });
+
+    await expect(
+      sendAttachmentAppleScript("friend", "/Users/tester/file.txt", undefined),
+    ).rejects.toThrow(MESSAGES_FDA_HINT);
+  });
+});


### PR DESCRIPTION
## Purpose

Explain the motivation for this change. Link any related issues.

Fixes #

## Key Changes

- 

## Local Run Notes

- Build: `npm run build`
- Dev (stdio): `npm run dev`
- Inspector (optional): `npm run inspector`
- Doctor: `npm run doctor` or `npm run doctor -- --json`

## Testing Plan

- Unit tests: `npm test`
- Manual tool checks via Inspector:
  - `doctor` → environment report
  - `list_chats` → lists recent chats
  - `get_messages` → recent messages by `chat_id` or `participant`
  - `send_text` → send a message (masking enabled by default)

## Security / Privacy

- Avoid logging message bodies or full phone numbers. Keep recipients masked in output unless explicitly revealing locally.
- Database access stays read-only via `sqlite3 -readonly -json`.
- AppleScript only used to send via Messages.app.

## Checklist

- [ ] Conventional Commit message (e.g., `feat:`, `fix:`, `docs:`)
- [ ] `npm run build` passes
- [ ] `npm test` passes locally (if applicable)
- [ ] `npm run doctor` produces expected guidance (ok on a configured Mac, or helpful notes otherwise)
- [ ] No unintended file changes
- [ ] No sensitive logs or PII committed

